### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/lastfp/__init__.py
+++ b/lastfp/__init__.py
@@ -163,7 +163,7 @@ def extract(pcmiter, samplerate, channels, duration = -1):
 
     # Get first block.
     try:
-        next_block = pcmiter.next()
+        next_block = next(pcmiter)
     except StopIteration:
         raise ExtractionError()
 
@@ -172,7 +172,7 @@ def extract(pcmiter, samplerate, channels, duration = -1):
         # Shift over blocks.
         cur_block = next_block
         try:
-            next_block = pcmiter.next()
+            next_block = next(pcmiter)
         except StopIteration:
             next_block = None
         done = next_block is None
@@ -182,7 +182,7 @@ def extract(pcmiter, samplerate, channels, duration = -1):
             if extractor.process(cur_block, done):
                 # Success!
                 break
-        except RuntimeError, exc:
+        except RuntimeError as exc:
             # Exception from fplib. Most likely the file is too short.
             raise ExtractionError(exc.args[0])
 

--- a/lastmatch.py
+++ b/lastmatch.py
@@ -9,6 +9,7 @@ makes it use MAD instead (which, of course, only works on MPEG audio
 such as MP3). To use the script, of course, you'll need to have
 either Gstreamer (and its Python bindings) or pymad installed.
 """
+from __future__ import print_function
 import sys
 import os
 
@@ -30,7 +31,7 @@ API_KEY = '7821ee9bf9937b7f94af2abecced8ddd'
 if __name__ == '__main__':
     args = sys.argv[1:]
     if not args:
-        print "usage: python lastmatch.py [-m] mysterious_music.mp3 [...]"
+        print("usage: python lastmatch.py [-m] mysterious_music.mp3 [...]")
         sys.exit(1)
     if args[0] == '-m':
         match_func = lastfp.mad_match
@@ -45,14 +46,14 @@ if __name__ == '__main__':
         try:
             xml = match_func(API_KEY, path)
         except lastfp.ExtractionError:
-            print 'fingerprinting failed!'
+            print('fingerprinting failed!')
             sys.exit(1)
         except lastfp.QueryError:
-            print 'could not match fingerprint!'
+            print('could not match fingerprint!')
             sys.exit(1)
 
         # Show results.
         matches = lastfp.parse_metadata(xml)
         for track in matches:
-            print '%f: %s - %s' % (track['rank'], track['artist'],
-                                   track['title'])
+            print('%f: %s - %s' % (track['rank'], track['artist'],
+                                   track['title']))

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 
@@ -59,7 +60,7 @@ else:
 # C++ source is included in the tarball also.
 if 'sdist' in sys.argv:
     if not HAVE_CYTHON:
-        print 'We need Cython to build a source distribution.'
+        print('We need Cython to build a source distribution.')
         sys.exit(1)
     from Cython.Compiler import Main
     source = ext.sources[0] # hacky!


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3. More work may be required to complete the port to Python 3 but this is a minimal, safe first step.

* [futurize stage 1](http://python-future.org/futurize_cheatsheet.html#step-1-modern-py2-code)
* pcmiter.next() --> next(pcmiter)
* except RuntimeError, exc: --> except RuntimeError as exc:
* print() function